### PR TITLE
Update aws-sdk to 2.2.0, fix spec and api S3 client instantiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "async": "^1.3.0",
     "mime": "^1.3.4",
-    "aws-sdk": "^1.18.0",
+    "aws-sdk": "^2.2.0",
     "powerfs": "^0.2.3",
     "q": "^2.0.3",
     "optimist": "^0.6.0",

--- a/spec/aws-client-spec.coffee
+++ b/spec/aws-client-spec.coffee
@@ -5,8 +5,8 @@ describe 'aws-client', ->
 
   it 'runs using the expected interface', ->
     AWS.config.update({
-      region: "eu-west-1"
+      region: "us-east-1"
       accessKeyId: "key"
       secretAccessKey: "secret"
     })
-    should.exist new AWS.S3().client
+    should.exist new AWS.S3().getObject

--- a/src/interface/api.coffee
+++ b/src/interface/api.coffee
@@ -18,7 +18,7 @@ exports.deploy = (options, callback) ->
         accessKeyId: key
         secretAccessKey: secret
       })
-      new AWS.S3().client
+      new AWS.S3()
   })
 
   deploy(finalConf, callback)


### PR DESCRIPTION
I was having some issues w/ bucketful using the 1.x.x aws-sdk (uploads would stall for no reason). Updated to the latest `aws-sdk` and things work great!
